### PR TITLE
set field touched after slug change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,16 +25,19 @@ const loadStyles = () => {
   }
 };
 
-registerFn(pluginInfo, (handler, client, { toast, getLanguage }) => {
-  loadStyles();
-  handler.on("flotiq.plugins.manage::render", (data) =>
-    handleManagePlugin(data, pluginInfo, client, toast, getLanguage)
-  );
-  handler.on("flotiq.form.field::config", (data) =>
-    handleFormFieldConfig(data, pluginInfo)
-  );
-  handler.on("flotiq.plugin::migrate", handleMigrate);
-});
+registerFn(
+  pluginInfo,
+  (handler, client, { toast, getLanguage, getPluginSettings }) => {
+    loadStyles();
+    handler.on("flotiq.plugins.manage::render", (data) =>
+      handleManagePlugin(data, pluginInfo, client, toast, getLanguage)
+    );
+    handler.on("flotiq.form.field::config", (data) =>
+      handleFormFieldConfig(data, pluginInfo, getPluginSettings)
+    );
+    handler.on("flotiq.plugin::migrate", handleMigrate);
+  }
+);
 
 const pluginManagePreviewRoot = document.getElementById("manage-preview-root");
 

--- a/src/plugin-manifest.json
+++ b/src/plugin-manifest.json
@@ -2,7 +2,7 @@
   "id": "flotiq.slug",
   "name": "Slug",
   "description": "This plugin automatically generates a slug based on existing data within a Content Object and enters the slug data into another field.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "repository": "https://github.com/flotiq/flotiq-ui-plugin-slug",
   "url": "http://localhost:3050/static/js/bundle.js",
   "permissions": [

--- a/src/plugin-manifest.json
+++ b/src/plugin-manifest.json
@@ -4,7 +4,7 @@
   "description": "This plugin automatically generates a slug based on existing data within a Content Object and enters the slug data into another field.",
   "version": "1.1.4",
   "repository": "https://github.com/flotiq/flotiq-ui-plugin-slug",
-  "url": "http://localhost:3050/static/js/bundle.js",
+  "url": "https://localhost:3050/static/js/bundle.js",
   "permissions": [
     {
       "ctdName": "_plugin_settings",

--- a/src/plugins/formFieldConfig.js
+++ b/src/plugins/formFieldConfig.js
@@ -1,9 +1,12 @@
 import slug from "slug";
 import { addElementToCache, getCachedElement } from "../common/plugin-helpers";
 
-const regenerate = (formik, fieldName, slugFieldName) => {
+const regenerate = async (formik, fieldName, slugFieldName) => {
   const source = formik.values[slugFieldName];
-  if (source) formik.setFieldValue(fieldName, slug(source));
+  if (source) {
+    await formik.setFieldValue(fieldName, slug(source));
+    formik.setFieldTouched(fieldName);
+  }
 };
 
 const handleCoForm = (
@@ -19,14 +22,15 @@ const handleCoForm = (
 
   if (!isEditing && sourceSettings.length) {
     config.onBlur = (e) => {
-      sourceSettings.forEach((fieldName) => {
+      sourceSettings.forEach(async (fieldName) => {
         const targetType =
           contentType.schemaDefinition.allOf[1].properties?.[fieldName]?.type;
 
         if (formik.values[fieldName] || targetType !== "string") return;
 
         const newValue = slug(value);
-        formik.setFieldValue(fieldName, newValue);
+        await formik.setFieldValue(fieldName, newValue);
+        formik.setFieldTouched(fieldName);
       });
 
       formik.handleBlur(e);

--- a/src/plugins/formFieldConfig.js
+++ b/src/plugins/formFieldConfig.js
@@ -72,14 +72,18 @@ const handleCoForm = (
 };
 
 export function handleFormFieldConfig(
-  { contentType, userPlugins, config, ...data },
-  pluginInfo
+  { contentType, config, ...data },
+  pluginInfo,
+  getPluginSettings
 ) {
   if (!config) return;
 
-  const slugSettings = JSON.parse(
-    userPlugins?.find(({ id }) => id === pluginInfo.id)?.settings || "[]"
-  )?.filter(({ content_type }) => content_type === contentType.name);
+  const pluginSettings = getPluginSettings();
+  const parsedSettings = JSON.parse(pluginSettings || "[]");
+
+  const slugSettings = parsedSettings?.filter(
+    ({ content_type }) => content_type === contentType.name
+  );
 
   if (slugSettings?.length > 0)
     return handleCoForm(


### PR DESCRIPTION
Fixed:
- when slug is generated/regenerated, field is touched
- get plugin settings from global helper instead of plugin data 